### PR TITLE
cloudbuild.yaml example

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,18 @@
+steps:
+  - id: npm-ci
+    name: node:10-alpine
+    env:
+      - "CI=1"
+    entrypoint: npm
+    args: ['ci']
+
+  - id: test
+    name: cypress/base:10
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        $(npm bin)/cypress verify && \
+        npm run test
+    waitFor:
+      - npm-ci


### PR DESCRIPTION
Added an example cloudbuild.yaml file that implements the testing steps in your Dockerfile.

To try it yourself:

`gcloud builds submit --config=cloudbuild.yaml --project=[YOUR_GCP_PROJECT_ID]`

My total execution time came to 2M 29S